### PR TITLE
Add a Home Screen 🍯 

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -45,7 +45,6 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodel)
-            implementation(libs.androidx.lifecycle.viewmodel.compose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(project(":ContextGuard"))
             implementation(libs.koin.core)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -33,6 +33,8 @@ kotlin {
         androidMain.dependencies {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
+            implementation(libs.koin.core)
+            implementation(libs.koin.android)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -43,8 +45,12 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(libs.androidx.lifecycle.viewmodel.compose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(project(":ContextGuard"))
+            implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -50,6 +50,7 @@ kotlin {
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
+            implementation(libs.material.icons)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/MsgVerifyApplication.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/MsgVerifyApplication.kt
@@ -1,0 +1,18 @@
+package com.terrydroid.msgverify
+
+import android.app.Application
+import com.terrydroid.msgverify.di.appModules
+import com.terrydroid.msgverify.di.initKoin
+import org.koin.android.ext.koin.androidContext
+
+class MsgVerifyApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+
+        initKoin {
+            androidContext(this@MsgVerifyApplication)
+
+            modules(appModules)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
@@ -1,25 +1,54 @@
 package com.terrydroid.msgverify
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.terrydroid.msgverify.di.commonModule
+import com.terrydroid.msgverify.home.HomeViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.KoinApplication
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.KoinApplication
 
 @Composable
-@Preview
 fun App() {
-    MaterialTheme {
-        Column(
-            modifier = Modifier
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+    KoinApplication(application = {
+        modules(commonModule())
+    }) {
+        MaterialTheme {
+            Column(
+                modifier = Modifier
+                    .safeContentPadding()
+                    .fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                val vm : HomeViewModel = koinViewModel()
 
+                Scaffold(
+                    contentWindowInsets = WindowInsets(0.dp)
+                ) { innerPadding ->
+                    Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+
+                    }
+                }
+            }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun AppPreview() {
+    MaterialTheme {
+        App()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
@@ -1,43 +1,73 @@
 package com.terrydroid.msgverify
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.terrydroid.msgverify.di.commonModule
 import com.terrydroid.msgverify.home.HomeViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
 import org.koin.compose.viewmodel.koinViewModel
-import org.koin.core.KoinApplication
 
 @Composable
 fun App() {
     KoinApplication(application = {
         modules(commonModule())
     }) {
-        MaterialTheme {
-            Column(
-                modifier = Modifier
-                    .safeContentPadding()
-                    .fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                val vm : HomeViewModel = koinViewModel()
+        AppScreen()
+    }
+}
 
-                Scaffold(
-                    contentWindowInsets = WindowInsets(0.dp)
-                ) { innerPadding ->
-                    Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+@Composable
+private fun AppScreen() {
+    MaterialTheme {
+        Column(
+            modifier = Modifier
+                .safeContentPadding()
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            val vm: HomeViewModel = koinViewModel()
 
+            Scaffold(
+                contentWindowInsets = WindowInsets(0.dp)
+            ) { innerPadding ->
+                Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                    Spacer(modifier = Modifier.size(160.dp))
+                    val textFieldValue = remember { mutableStateOf("") }
+                    OutlinedTextField(
+                        modifier = Modifier.fillMaxWidth(80f),
+                        value = textFieldValue.value,
+                        onValueChange = {
+                            textFieldValue.value = it
+                        },
+                        placeholder = {
+                            Text("Enter Url you want to verify")
+                        }
+                    )
+
+                    Button(
+                        onClick = {
+                            vm.onVerifyClicked(textFieldValue.value)
+                        }
+                    ) {
+                        Text("Verify")
                     }
                 }
             }
@@ -49,6 +79,6 @@ fun App() {
 @Composable
 private fun AppPreview() {
     MaterialTheme {
-        App()
+        AppScreen()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
@@ -1,29 +1,19 @@
 package com.terrydroid.msgverify
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.terrydroid.msgverify.di.commonModule
-import com.terrydroid.msgverify.home.HomeViewModel
+import com.terrydroid.msgverify.home.HomeScreen
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
-import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun App() {
@@ -43,33 +33,13 @@ private fun AppScreen() {
                 .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val vm: HomeViewModel = koinViewModel()
 
             Scaffold(
                 contentWindowInsets = WindowInsets(0.dp)
             ) { innerPadding ->
-                Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-                    Spacer(modifier = Modifier.size(160.dp))
-                    val textFieldValue = remember { mutableStateOf("") }
-                    OutlinedTextField(
-                        modifier = Modifier.fillMaxWidth(80f),
-                        value = textFieldValue.value,
-                        onValueChange = {
-                            textFieldValue.value = it
-                        },
-                        placeholder = {
-                            Text("Enter Url you want to verify")
-                        }
-                    )
-
-                    Button(
-                        onClick = {
-                            vm.onVerifyClicked(textFieldValue.value)
-                        }
-                    ) {
-                        Text("Verify")
-                    }
-                }
+                HomeScreen(
+                    paddingValues = innerPadding
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
@@ -1,8 +1,25 @@
 package com.terrydroid.msgverify.data
 
+import io.ktor.http.Url
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import org.koin.core.component.KoinComponent
 
 
 class MsgVerifyRepository : KoinComponent {
 
+    suspend fun verifyLink(url: Url): Flow<Result<LinkVerificationResponse>> {
+
+        //TODO: Integrate with model. Now it will just return a mock score
+        return flowOf(Result.success(LinkVerificationResponse(maliciousScore = 0.64f)))
+    }
 }
+
+/**
+ * After asking the machine learning model if the link is malicious,
+ * it will return a score. This is the @property maliciousScore. This is a pecentage
+ * 0 - 1
+ */
+data class LinkVerificationResponse(
+    val maliciousScore: Float
+)

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
@@ -10,7 +10,7 @@ class MsgVerifyRepository : KoinComponent {
     suspend fun verifyLink(url: String): Flow<Result<LinkVerificationResponse>> {
 
         //TODO: Integrate with model. Now it will just return a mock score
-        return flowOf(Result.success(LinkVerificationResponse(maliciousScore = 0.64f)))
+        return flowOf(Result.success(LinkVerificationResponse(maliciousScore = 0.45f)))
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
@@ -1,0 +1,8 @@
+package com.terrydroid.msgverify.data
+
+import org.koin.core.component.KoinComponent
+
+
+class MsgVerifyRepository : KoinComponent {
+
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/data/MsgVerifyRepository.kt
@@ -1,6 +1,5 @@
 package com.terrydroid.msgverify.data
 
-import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.koin.core.component.KoinComponent
@@ -8,7 +7,7 @@ import org.koin.core.component.KoinComponent
 
 class MsgVerifyRepository : KoinComponent {
 
-    suspend fun verifyLink(url: Url): Flow<Result<LinkVerificationResponse>> {
+    suspend fun verifyLink(url: String): Flow<Result<LinkVerificationResponse>> {
 
         //TODO: Integrate with model. Now it will just return a mock score
         return flowOf(Result.success(LinkVerificationResponse(maliciousScore = 0.64f)))

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/di/AppModules.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/di/AppModules.kt
@@ -1,0 +1,10 @@
+package com.terrydroid.msgverify.di
+
+import com.terrydroid.msgverify.data.MsgVerifyRepository
+import org.koin.dsl.module
+
+val appModules = module {
+    single<MsgVerifyRepository> {
+        MsgVerifyRepository()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/di/Koin.kt
@@ -1,0 +1,24 @@
+package com.terrydroid.msgverify.di
+
+import com.terrydroid.msgverify.data.MsgVerifyRepository
+import com.terrydroid.msgverify.home.HomeViewModel
+import org.koin.compose.viewmodel.dsl.viewModel
+import org.koin.core.context.startKoin
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.KoinAppDeclaration
+import org.koin.dsl.module
+
+
+fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
+    startKoin {
+        modules(commonModule())
+        appDeclaration()
+    }
+
+// called by iOS client
+fun initKoin() = initKoin {}
+
+fun commonModule() = module {
+    singleOf(::MsgVerifyRepository)
+    viewModel { HomeViewModel(msgVerifyRepository = get()) }
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
@@ -1,0 +1,104 @@
+package com.terrydroid.msgverify.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.compose.viewmodel.koinViewModel
+
+@Composable
+internal fun HomeScreen(
+    homeViewModel: HomeViewModel = koinViewModel(),
+    paddingValues: PaddingValues
+) {
+    val linkVerificationState =
+        homeViewModel
+            .linkVerificationState
+            .collectAsStateWithLifecycle()
+            .value
+
+    Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = "MsgVerify",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.size(64.dp))
+        val textFieldValue = remember { mutableStateOf("") }
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(80f),
+            value = textFieldValue.value,
+            onValueChange = {
+                textFieldValue.value = it
+            },
+            placeholder = {
+                Text(text = "Enter Url you want to verify")
+            },
+            isError = linkVerificationState is LinkVerificationState.Error,
+            label = {
+                if (linkVerificationState is LinkVerificationState.Error) {
+                    Text(linkVerificationState.errorMessage)
+                }
+            }
+        )
+
+        Button(
+            modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 16.dp),
+            onClick = {
+                homeViewModel.onVerifyClicked(textFieldValue.value)
+            },
+            enabled = textFieldValue.value.isNotEmpty()
+        ) {
+            Text(text = "Verify")
+        }
+
+        when (linkVerificationState) {
+            is LinkVerificationState.Error -> {
+                Text(linkVerificationState.errorMessage)
+            }
+
+            LinkVerificationState.Idle -> {
+                /* NO-OP */
+            }
+
+            LinkVerificationState.LoadingVerification -> {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "Processing link",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+
+            is LinkVerificationState.Success -> {
+                Spacer(Modifier.size(24.dp))
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = "There is a ${linkVerificationState.linkMaliciousPercentage} % " +
+                            "chance its malicious",
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
@@ -56,7 +56,8 @@ internal fun HomeScreen(
                 if (linkVerificationState is LinkVerificationState.Error) {
                     Text(linkVerificationState.errorMessage)
                 }
-            }
+            },
+            maxLines = 1
         )
 
         Button(
@@ -69,9 +70,17 @@ internal fun HomeScreen(
             Text(text = "Verify")
         }
 
+        Spacer(modifier = Modifier.size(16.dp))
+
         when (linkVerificationState) {
             is LinkVerificationState.Error -> {
-                Text(linkVerificationState.errorMessage)
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = linkVerificationState.errorMessage,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
             }
 
             LinkVerificationState.Idle -> {
@@ -83,7 +92,7 @@ internal fun HomeScreen(
                     modifier = Modifier.fillMaxWidth(),
                     text = "Processing link",
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.labelMedium,
+                    style = MaterialTheme.typography.displaySmall,
                     color = MaterialTheme.colorScheme.onBackground
                 )
             }
@@ -95,7 +104,7 @@ internal fun HomeScreen(
                     text = "There is a ${linkVerificationState.linkMaliciousPercentage} % " +
                             "chance its malicious",
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.labelMedium,
+                    style = MaterialTheme.typography.displaySmall,
                     color = MaterialTheme.colorScheme.onBackground
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
@@ -1,13 +1,24 @@
 package com.terrydroid.msgverify.home
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Policy
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -32,82 +43,145 @@ internal fun HomeScreen(
             .collectAsStateWithLifecycle()
             .value
 
-    Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            text = "MsgVerify",
-            style = MaterialTheme.typography.headlineMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-            textAlign = TextAlign.Center
-        )
-        Spacer(modifier = Modifier.size(64.dp))
-        val textFieldValue = remember { mutableStateOf("") }
-        OutlinedTextField(
-            modifier = Modifier.fillMaxWidth(70f),
-            value = textFieldValue.value,
-            onValueChange = {
-                textFieldValue.value = it
-            },
-            placeholder = {
-                Text(text = "Enter Url you want to verify")
-            },
-            isError = linkVerificationState is LinkVerificationState.Error,
-            label = {
-                if (linkVerificationState is LinkVerificationState.Error) {
-                    Text(linkVerificationState.errorMessage)
-                }
-            },
-            maxLines = 1
-        )
-
-        Button(
-            modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 16.dp),
-            onClick = {
-                homeViewModel.onVerifyClicked(textFieldValue.value)
-            },
-            enabled = textFieldValue.value.isNotEmpty()
-        ) {
-            Text(text = "Verify")
+    LazyColumn(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+        item {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = "MsgVerify",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Center
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.size(64.dp))
         }
 
-        Spacer(modifier = Modifier.size(16.dp))
+        item {
+            val textFieldValue = remember { mutableStateOf("") }
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(70f),
+                value = textFieldValue.value,
+                onValueChange = {
+                    textFieldValue.value = it
+                },
+                placeholder = {
+                    Text(text = "Enter Url you want to verify")
+                },
+                isError = linkVerificationState is LinkVerificationState.Error,
+                label = {
+                    if (linkVerificationState is LinkVerificationState.Error) {
+                        Text(linkVerificationState.errorMessage)
+                    } else {
+                        Text("Input a url to verify")
+                    }
+                },
+                maxLines = 1,
+                shape = RoundedCornerShape(8.dp),
+                trailingIcon = {
+                    Icon(imageVector = Icons.Default.Policy, contentDescription = null)
+                }
+            )
+
+            Button(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                onClick = {
+                    homeViewModel.onVerifyClicked(textFieldValue.value)
+                },
+                enabled = textFieldValue.value.isNotEmpty()
+            ) {
+                Text(
+                    modifier = Modifier.padding(8.dp),
+                    text = "Verify"
+                )
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.size(16.dp))
+        }
 
         when (linkVerificationState) {
             is LinkVerificationState.Error -> {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = linkVerificationState.errorMessage,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.onBackground
-                )
+                /* Handled in the text field */
             }
 
-            LinkVerificationState.Idle -> {
+            is LinkVerificationState.Idle -> {
                 /* NO-OP */
             }
 
-            LinkVerificationState.LoadingVerification -> {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = "Processing link",
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.displaySmall,
-                    color = MaterialTheme.colorScheme.onBackground
-                )
+            is LinkVerificationState.LoadingVerification -> {
+                item {
+                    CircularProgressIndicator()
+                }
             }
 
             is LinkVerificationState.Success -> {
-                Spacer(Modifier.size(24.dp))
+
+                item {
+                    //TODO: Implement warning and success colors
+                    val textColor = when (linkVerificationState.linkResult.classificationColor) {
+                        ClassificationColor.Red -> MaterialTheme.colorScheme.error
+                        ClassificationColor.Yellow -> MaterialTheme.colorScheme.onBackground
+                        ClassificationColor.Green -> MaterialTheme.colorScheme.onBackground
+                    }
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = "There is a ${linkVerificationState.linkResult.linkMaliciousPercentage} % " +
+                                "chance it's malicious",
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = textColor
+                    )
+                }
+            }
+        }
+
+        item {
+            if (linkVerificationState.verifiedLinkHistory.isNotEmpty()) {
                 Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = "There is a ${linkVerificationState.linkMaliciousPercentage} % " +
-                            "chance its malicious",
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.displaySmall,
+                    modifier = Modifier.padding(top = 24.dp),
+                    text = "Previously verified links",
+                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onBackground
                 )
             }
         }
+
+        items(linkVerificationState.verifiedLinkHistory) { item ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = item.url,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val icon = when (item.classificationColor) {
+                        ClassificationColor.Red -> Icons.Default.Error
+                        ClassificationColor.Yellow -> Icons.Default.Warning
+                        ClassificationColor.Green -> Icons.Default.Shield
+                    }
+                    Icon(
+                        modifier = Modifier.padding(4.dp),
+                        imageVector = icon,
+                        contentDescription = null
+                    )
+                    Text(
+                        text = "${item.linkMaliciousPercentage} %",
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            }
+        }
+
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeScreen.kt
@@ -43,7 +43,7 @@ internal fun HomeScreen(
         Spacer(modifier = Modifier.size(64.dp))
         val textFieldValue = remember { mutableStateOf("") }
         OutlinedTextField(
-            modifier = Modifier.fillMaxWidth(80f),
+            modifier = Modifier.fillMaxWidth(70f),
             value = textFieldValue.value,
             onValueChange = {
                 textFieldValue.value = it

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
@@ -1,14 +1,19 @@
 package com.terrydroid.msgverify.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.terrydroid.msgverify.data.LinkVerificationResponse
 import com.terrydroid.msgverify.data.MsgVerifyRepository
+import io.ktor.http.URLParserException
+import io.ktor.http.Url
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 
 class HomeViewModel(
-    msgVerifyRepository: MsgVerifyRepository
+    private val msgVerifyRepository: MsgVerifyRepository
 ) : ViewModel() {
 
     private val _linkVerificationState: MutableStateFlow<LinkVerificationState> = MutableStateFlow(
@@ -21,15 +26,22 @@ class HomeViewModel(
     fun onVerifyClicked(inputLink: String) {
 
         //TODO: Do verification that it is actually a link
+        viewModelScope.launch {
+            try {
+                val url = Url(inputLink)
+                msgVerifyRepository.verifyLink(url).collect { result ->
+                    if (result.isSuccess) {
+                        _linkVerificationState.value = LinkVerificationState.Success()
+                    }
+                }
+            } catch (e: URLParserException) {
+                _linkVerificationState.value = LinkVerificationState.Error("Not a valid url")
+            }
+        }
 
     }
 
 }
 
-sealed class LinkVerificationState {
-    data object Idle : LinkVerificationState()
-    data object LoadingVerification : LinkVerificationState()
-    data class Error(val errorMessage: String) : LinkVerificationState()
-    data class Success(val linkMaliciousPercentage: String) : LinkVerificationState()
-}
+
 

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
@@ -14,27 +14,54 @@ class HomeViewModel(
 ) : ViewModel() {
 
     private val _linkVerificationState: MutableStateFlow<LinkVerificationState> = MutableStateFlow(
-        LinkVerificationState.Idle
+        LinkVerificationState.Idle(emptyList())
     )
 
     val linkVerificationState: StateFlow<LinkVerificationState>
         get() = _linkVerificationState.asStateFlow()
 
+
     fun onVerifyClicked(inputLink: String) {
         if (!isValidUrl(inputLink)) {
-            _linkVerificationState.value = LinkVerificationState.Error("Is not a valid url")
+            _linkVerificationState.value = LinkVerificationState.Error(
+                errorMessage = "Is not a valid url",
+                verifiedLinkHistory = _linkVerificationState.value.verifiedLinkHistory
+            )
         } else {
             viewModelScope.launch {
                 msgVerifyRepository.verifyLink(inputLink).collect { result ->
                     result.fold(
                         onSuccess = {
                             val maliciousScorePercent = it.maliciousScore * 100
+
+                            //TODO: Change these when we agree on threshold
+                            val classificationColor = if (maliciousScorePercent < 40) {
+                                ClassificationColor.Green
+                            } else if (maliciousScorePercent >= 40 && maliciousScorePercent < 70) {
+                                ClassificationColor.Yellow
+                            } else {
+                                ClassificationColor.Red
+                            }
+                            val linkResult = LinkResult(
+                                linkMaliciousPercentage = maliciousScorePercent,
+                                classificationColor = classificationColor,
+                                url = inputLink
+                            )
+                            val newVerifierLinkHistory = listOf(linkResult) + _linkVerificationState
+                                .value
+                                .verifiedLinkHistory
+
                             _linkVerificationState.value =
-                                LinkVerificationState.Success("$maliciousScorePercent")
+                                LinkVerificationState.Success(
+                                    linkResult = linkResult,
+                                    verifiedLinkHistory = newVerifierLinkHistory
+                                )
                         },
                         onFailure = {
-                            _linkVerificationState.value =
-                                LinkVerificationState.Error("Could not get score")
+                            _linkVerificationState.value = LinkVerificationState.Error(
+                                errorMessage = "Could not get the score for this link",
+                                verifiedLinkHistory = _linkVerificationState.value.verifiedLinkHistory
+                            )
                         }
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
@@ -2,10 +2,7 @@ package com.terrydroid.msgverify.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.terrydroid.msgverify.data.LinkVerificationResponse
 import com.terrydroid.msgverify.data.MsgVerifyRepository
-import io.ktor.http.URLParserException
-import io.ktor.http.Url
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,18 +21,23 @@ class HomeViewModel(
         get() = _linkVerificationState.asStateFlow()
 
     fun onVerifyClicked(inputLink: String) {
-
-        //TODO: Do verification that it is actually a link
-        viewModelScope.launch {
-            try {
-                val url = Url(inputLink)
-                msgVerifyRepository.verifyLink(url).collect { result ->
-                    if (result.isSuccess) {
-                        _linkVerificationState.value = LinkVerificationState.Success()
-                    }
+        if (!isValidUrl(inputLink)) {
+            _linkVerificationState.value = LinkVerificationState.Error("Is not a valid url")
+        } else {
+            viewModelScope.launch {
+                msgVerifyRepository.verifyLink(inputLink).collect { result ->
+                    result.fold(
+                        onSuccess = {
+                            val maliciousScorePercent = it.maliciousScore * 100
+                            _linkVerificationState.value =
+                                LinkVerificationState.Success("$maliciousScorePercent")
+                        },
+                        onFailure = {
+                            _linkVerificationState.value =
+                                LinkVerificationState.Error("Could not get score")
+                        }
+                    )
                 }
-            } catch (e: URLParserException) {
-                _linkVerificationState.value = LinkVerificationState.Error("Not a valid url")
             }
         }
 
@@ -43,5 +45,13 @@ class HomeViewModel(
 
 }
 
-
+//TODO: Change to some common url checking that works on CMP
+private fun isValidUrl(url: String): Boolean {
+    return Regex(
+        "^https?://[\\w\\-]+(\\.[\\w\\-]+)+[/#?]?.*\$",
+        RegexOption.IGNORE_CASE
+    ).matches(
+        url
+    )
+}
 

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
@@ -1,0 +1,15 @@
+package com.terrydroid.msgverify.home
+
+import androidx.lifecycle.ViewModel
+import com.terrydroid.msgverify.data.MsgVerifyRepository
+import org.koin.core.component.inject
+import kotlin.getValue
+
+
+class HomeViewModel(
+   msgVerifyRepository: MsgVerifyRepository
+): ViewModel() {
+
+
+}
+

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/HomeViewModel.kt
@@ -2,14 +2,34 @@ package com.terrydroid.msgverify.home
 
 import androidx.lifecycle.ViewModel
 import com.terrydroid.msgverify.data.MsgVerifyRepository
-import org.koin.core.component.inject
-import kotlin.getValue
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 
 class HomeViewModel(
-   msgVerifyRepository: MsgVerifyRepository
-): ViewModel() {
+    msgVerifyRepository: MsgVerifyRepository
+) : ViewModel() {
 
+    private val _linkVerificationState: MutableStateFlow<LinkVerificationState> = MutableStateFlow(
+        LinkVerificationState.Idle
+    )
 
+    val linkVerificationState: StateFlow<LinkVerificationState>
+        get() = _linkVerificationState.asStateFlow()
+
+    fun onVerifyClicked(inputLink: String) {
+
+        //TODO: Do verification that it is actually a link
+
+    }
+
+}
+
+sealed class LinkVerificationState {
+    data object Idle : LinkVerificationState()
+    data object LoadingVerification : LinkVerificationState()
+    data class Error(val errorMessage: String) : LinkVerificationState()
+    data class Success(val linkMaliciousPercentage: String) : LinkVerificationState()
 }
 

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/LinkVerificationState.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/LinkVerificationState.kt
@@ -1,8 +1,34 @@
 package com.terrydroid.msgverify.home
 
-sealed class LinkVerificationState {
-    data object Idle : LinkVerificationState()
-    data object LoadingVerification : LinkVerificationState()
-    data class Error(val errorMessage: String) : LinkVerificationState()
-    data class Success(val linkMaliciousPercentage: String) : LinkVerificationState()
+sealed interface LinkVerificationState {
+    val verifiedLinkHistory: List<LinkResult>
+
+    data class Idle(
+        override val verifiedLinkHistory: List<LinkResult>
+    ) : LinkVerificationState
+
+    data class LoadingVerification(
+        override val verifiedLinkHistory: List<LinkResult>
+    ) : LinkVerificationState
+
+    data class Error(
+        val errorMessage: String,
+        override val verifiedLinkHistory: List<LinkResult>
+    ) : LinkVerificationState
+
+    data class Success(
+        val linkResult: LinkResult,
+        override val verifiedLinkHistory: List<LinkResult>
+    ) : LinkVerificationState
 }
+
+data class LinkResult(
+    val linkMaliciousPercentage: Float,
+    val classificationColor: ClassificationColor,
+    val url: String
+)
+
+enum class ClassificationColor {
+    Red, Yellow, Green
+}
+

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/LinkVerificationState.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/home/LinkVerificationState.kt
@@ -1,0 +1,8 @@
+package com.terrydroid.msgverify.home
+
+sealed class LinkVerificationState {
+    data object Idle : LinkVerificationState()
+    data object LoadingVerification : LinkVerificationState()
+    data class Error(val errorMessage: String) : LinkVerificationState()
+    data class Success(val linkMaliciousPercentage: String) : LinkVerificationState()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,9 @@ kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", versio
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
 androidx-core = { group = "androidx.test", name = "core", version.ref = "core" }
 
+# Material
+material-icons = { module = "org.jetbrains.compose.material:material-icons-core", version.require = "1.7.3"}
+
 # ktor
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,10 +21,15 @@ ktor = "3.2.0"
 kotlinx-serialization = "1.6.3"
 kotlinx-coroutines = "1.8.0"
 pytorchLiteMultiplatform = "0.7.0"
+koin = "4.0.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin"}
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin"}
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koin"}
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
@@ -33,6 +38,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle"}
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinStdlib" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,9 +8,9 @@ androidx-appcompat = "1.7.0"
 androidx-constraintlayout = "2.2.1"
 androidx-core = "1.16.0"
 androidx-espresso = "3.6.1"
-androidx-lifecycle = "2.9.0"
+androidx-lifecycle = "2.9.1"
 androidx-testExt = "1.2.1"
-composeMultiplatform = "1.8.1"
+composeMultiplatform = "1.8.2"
 junit = "4.13.2"
 kotlin = "2.1.21"
 kotlinStdlib = "2.1.21"
@@ -38,7 +38,6 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle"}
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinStdlib" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }


### PR DESCRIPTION
Started on the Home Screen so that we can start testing the model integration on both the iOS and Android apps.

Implemented text field with a repository injected with Koin. In the repository I'm just returning mock for now. But I imagine here is where we will integrate the data source somehow.

The data I piped to the UI showing the percentage score the url got. 

Implemented some client side check for the url. I couldn't find a good way to verify the url that worked in CMP, so I used regex for now. Let's look into that later.

Android
<img width="240" alt="image" src="https://github.com/user-attachments/assets/e891c5d2-7903-4691-be20-b3f51fb2955b" />

iOS
<img width="460" alt="image" src="https://github.com/user-attachments/assets/b25ba8c3-04ec-48ad-bd3e-82a6ae22a074" />


Will refactor the code a bit at a later point, but I think this will be fine for now.