### PR TITLE
Add theme that wraps material theme

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import com.terrydroid.msgverify.di.commonModule
 import com.terrydroid.msgverify.home.HomeScreen
 import com.terrydroid.msgverify.home.HomeViewModel
+import com.terrydroid.msgverify.theme.MsgVerifyTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
 import org.koin.compose.viewmodel.koinViewModel
@@ -29,12 +30,12 @@ fun App() {
 
 @Composable
 private fun AppScreen() {
-    MaterialTheme(colorScheme = MaterialTheme.colorScheme) {
+    MsgVerifyTheme {
         Column(
             modifier = Modifier
+                .background(color = MaterialTheme.colorScheme.background)
                 .safeContentPadding()
-                .fillMaxSize()
-                .background(color = MaterialTheme.colorScheme.background),
+                .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Scaffold(
@@ -51,7 +52,7 @@ private fun AppScreen() {
 @Preview
 @Composable
 private fun AppPreview() {
-    MaterialTheme {
+    MsgVerifyTheme {
         AppScreen()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/theme/MsgVerifyTheme.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/theme/MsgVerifyTheme.kt
@@ -1,0 +1,24 @@
+package com.terrydroid.msgverify.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+fun MsgVerifyTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        darkTheme -> darkColorScheme()
+        else -> lightColorScheme()
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography =  Typography,
+        content = content
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/theme/Typography.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/theme/Typography.kt
@@ -1,0 +1,35 @@
+package com.terrydroid.msgverify.theme
+
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Set of Material typography styles to start with
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+    /* Other default text styles to override
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+    */
+)


### PR DESCRIPTION
Let the dark mode begin!

Android

![image](https://github.com/user-attachments/assets/b2f9ed21-7741-4cc3-bc16-b7f316491a5f)


iOS
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-13 at 01 30 10" src="https://github.com/user-attachments/assets/9eb2078a-1a9f-443c-b1c5-329ff5cb66db" />
