### PR TITLE
WIP: Overlay example usage

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.koin.core)
             implementation(libs.koin.android)
+            implementation("com.google.mlkit:text-recognition:16.0.1")
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:name=".MsgVerifyApplication"
@@ -21,6 +22,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".overlay.OverlayService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,10 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
 
     <application
         android:name=".MsgVerifyApplication"
@@ -22,9 +26,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".overlay.CaptureImagePermissionActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"/>
         <service
             android:name=".overlay.OverlayService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
     </application>
 
 </manifest>

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/MainActivity.kt
@@ -8,9 +8,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.net.toUri
+import com.terrydroid.msgverify.overlay.CaptureImagePermissionActivity
 import com.terrydroid.msgverify.overlay.OverlayService
 
 class MainActivity : ComponentActivity() {
@@ -18,21 +20,35 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
+            var firstTime = rememberSaveable { true }
             val context = LocalContext.current
             App(onOverlayEnable = { checked ->
                 if (checked) askDrawOverlayPermissionIfNotGiven(
                     context
                 )
+                if (firstTime) {
+                    launchCapturePermissionActivity()
+                    firstTime = false
 
-                if (Settings.canDrawOverlays(context)) {
-                    val serviceIntent = Intent(context, OverlayService::class.java)
+                } else {
 
-                    if (checked) {
-                        context.startService(serviceIntent)
-                    } else context.stopService(serviceIntent)
+                    if (Settings.canDrawOverlays(context)) {
+                        val serviceIntent = Intent(context, OverlayService::class.java)
+
+                        if (checked) {
+                            context.startService(serviceIntent)
+                        } else context.stopService(serviceIntent)
+                    }
                 }
             })
         }
+    }
+    private fun launchCapturePermissionActivity() {
+        val intent = Intent(this, CaptureImagePermissionActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+        }
+        startActivity(intent)
     }
 }
 private fun askDrawOverlayPermissionIfNotGiven(context: Context) {

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/MainActivity.kt
@@ -1,25 +1,53 @@
 package com.terrydroid.msgverify
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.net.toUri
+import com.terrydroid.msgverify.overlay.OverlayService
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
         setContent {
-            App()
+            val context = LocalContext.current
+            App(onOverlayEnable = { checked ->
+                if (checked) askDrawOverlayPermissionIfNotGiven(
+                    context
+                )
+
+                if (Settings.canDrawOverlays(context)) {
+                    val serviceIntent = Intent(context, OverlayService::class.java)
+
+                    if (checked) {
+                        context.startService(serviceIntent)
+                    } else context.stopService(serviceIntent)
+                }
+            })
         }
     }
 }
+private fun askDrawOverlayPermissionIfNotGiven(context: Context) {
+    val canDrawOverlays = Settings.canDrawOverlays(context)
 
+    if (!canDrawOverlays) {
+        val permissionIntent = Intent(
+            Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+            "package:${context.packageName}".toUri()
+        )
+        context.startActivity(permissionIntent)
+    }
+}
 @Preview
 @Composable
 fun AppAndroidPreview() {
-    App()
+    App(onOverlayEnable = {})
 }

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/CaptureImagePermissionActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/CaptureImagePermissionActivity.kt
@@ -1,0 +1,34 @@
+package com.terrydroid.msgverify.overlay
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.media.projection.MediaProjectionManager
+import android.os.Bundle
+import androidx.core.content.ContextCompat
+
+class CaptureImagePermissionActivity : Activity() {
+
+    private val REQ_CAPTURE = 1001
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val mpm = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+        startActivityForResult(mpm.createScreenCaptureIntent(), REQ_CAPTURE)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (requestCode == REQ_CAPTURE && resultCode == RESULT_OK && data != null) {
+            val svc = Intent(this, OverlayService::class.java).apply {
+                putExtra("resultCode", resultCode)
+                putExtra("data", data) // Intent is Parcelable
+                putExtra("action", "START_PROJECTION")
+            }
+            ContextCompat.startForegroundService(this, svc)
+        }
+
+        finish()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayLifecycleOwner.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayLifecycleOwner.kt
@@ -1,0 +1,30 @@
+package com.terrydroid.msgverify.overlay
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+
+/**
+ * A lifecycle owner for overlay service to make compose work.
+ */
+internal class OverlayLifecycleOwner : SavedStateRegistryOwner {
+    private var mLifecycleRegistry: LifecycleRegistry = LifecycleRegistry(this)
+    private var mSavedStateRegistryController: SavedStateRegistryController =
+        SavedStateRegistryController.create(this)
+
+    fun handleLifecycleEvent(event: Lifecycle.Event) {
+        mLifecycleRegistry.handleLifecycleEvent(event)
+    }
+
+    fun performRestore(savedState: Bundle?) {
+        mSavedStateRegistryController.performRestore(savedState)
+    }
+
+    override val lifecycle: Lifecycle
+        get() = mLifecycleRegistry
+    override val savedStateRegistry: SavedStateRegistry
+        get() = mSavedStateRegistryController.savedStateRegistry
+}

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayScreen.kt
@@ -1,0 +1,224 @@
+package com.terrydroid.msgverify.overlay
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.List
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.Divider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+@Suppress("ComplexMethod")
+@Composable
+fun OverlayScreen(
+    onCancel: () -> Unit,
+    onDragStarted: () -> Pair<Offset, Int>,
+    onDragEnd: (Offset, shouldRemoveView: Boolean) -> Unit,
+) {
+    var offsetX by rememberSaveable { mutableFloatStateOf(0f) }
+    var offsetY by rememberSaveable { mutableFloatStateOf(0f) }
+    var isDragging by remember { mutableStateOf(false) }
+    var cancelPosition by remember { mutableStateOf(Rect.Zero) }
+    var boxPosition by remember { mutableStateOf(Rect.Zero) }
+    val isOverlapping by remember {
+        derivedStateOf {
+            boxPosition.bottom >= cancelPosition.top
+        }
+    }
+
+    Box {
+        Box(modifier = Modifier
+            .offset {
+                IntOffset(
+                    offsetX.roundToInt(),
+                    offsetY.roundToInt()
+                )
+            }
+            .pointerInput(Unit) {
+                detectDragGestures(
+                    onDragStart = {
+                        isDragging = true
+                        val (offsetInScreen, statusBarHeight) = onDragStarted()
+                        offsetX = offsetInScreen.x
+                        offsetY = offsetInScreen.y - statusBarHeight
+                    },
+                    onDragEnd = {
+                        isDragging = false
+                        onDragEnd(
+                            Offset(offsetX, offsetY),
+                            isOverlapping
+                        )
+                        offsetX = 0f
+                        offsetY = 0f
+                    },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        offsetX = (offsetX + dragAmount.x)
+                        offsetY = (offsetY + dragAmount.y)
+                    },
+                    onDragCancel = { onCancel() }
+                )
+            }
+            .onGloballyPositioned {
+                boxPosition = it.boundsInParent()
+            }
+        ) {
+            Overlay(
+                isAboutToRemove = isOverlapping && isDragging,
+            )
+        }
+
+        if (isDragging) {
+            // A gradient background to make sure we have enough contrast for the content
+            val colorStops = arrayOf(
+                0f to Color.Transparent,
+                0.5f to Color.Black.copy(alpha = 0.3f),
+                1f to Color.Black.copy(alpha = 0.6f),
+            )
+
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .height(100.dp)
+                    .fillMaxWidth()
+                    .background(
+                        Brush.verticalGradient(colorStops = colorStops)
+                    )
+                    .onGloballyPositioned {
+                        cancelPosition = it.boundsInParent()
+                    },
+            ) {
+                // This value is used to make sure that the haptic feedback is given only one time
+                var resetHapticFeedback by remember {
+                    mutableStateOf(false)
+                }
+
+                var isHapticFeedbackGiven by remember {
+                    mutableStateOf(false)
+                }
+
+                LaunchedEffect(Unit) {
+                    if (resetHapticFeedback) {
+                        isHapticFeedbackGiven = false
+                        resetHapticFeedback = false
+                    }
+
+                    if (!isOverlapping) {
+                        resetHapticFeedback = true
+                    }
+                }
+
+                if (isOverlapping && !isHapticFeedbackGiven) {
+                    isHapticFeedbackGiven = true
+                    LocalHapticFeedback.current.performHapticFeedback(
+                        HapticFeedbackType.LongPress
+                    )
+                }
+
+                Icon(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .size(48.dp)
+
+                        .align(Alignment.Center),
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Overlay(
+    modifier: Modifier = Modifier,
+    isAboutToRemove: Boolean,
+) {
+    val analyticsBoxHeight = remember { mutableStateOf(150.dp) }
+    val expanded = rememberSaveable { mutableStateOf(false) }
+
+    val backgroundColor = if (isAboutToRemove) {
+        // Just make the background a bit reddish when removing
+        val red = if (isSystemInDarkTheme()) 1f else 0.3f
+        Color.Red
+    } else MaterialTheme.colorScheme.background
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(backgroundColor)
+            .shadow(
+                elevation = 1.dp,
+                shape = RoundedCornerShape(8.dp)
+            ),
+    ) {
+        val analyticsContentModifier = Modifier
+            .animateContentSize(
+                spring(stiffness = Spring.StiffnessLow)
+            )
+            .clickable { expanded.value = !expanded.value }
+
+        if (expanded.value) {
+            Column(
+                modifier = analyticsContentModifier
+                    .width(300.dp)
+                    .height(analyticsBoxHeight.value)
+                    .background(backgroundColor)
+                    .verticalScroll(rememberScrollState())
+            ) {
+
+            }
+        } else {
+            Icon(
+                modifier = analyticsContentModifier
+                    .background(backgroundColor)
+                    .padding(16.dp),
+                imageVector = Icons.AutoMirrored.Rounded.List,
+                contentDescription = null
+            )
+        }
+    }
+}
+

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayScreen.kt
@@ -20,10 +20,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.List
+import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -56,6 +59,7 @@ fun OverlayScreen(
     onCancel: () -> Unit,
     onDragStarted: () -> Pair<Offset, Int>,
     onDragEnd: (Offset, shouldRemoveView: Boolean) -> Unit,
+    takeScreenShot: () -> Unit
 ) {
     var offsetX by rememberSaveable { mutableFloatStateOf(0f) }
     var offsetY by rememberSaveable { mutableFloatStateOf(0f) }
@@ -107,6 +111,7 @@ fun OverlayScreen(
         ) {
             Overlay(
                 isAboutToRemove = isOverlapping && isDragging,
+                takeScreenShot = takeScreenShot
             )
         }
 
@@ -175,6 +180,7 @@ fun OverlayScreen(
 private fun Overlay(
     modifier: Modifier = Modifier,
     isAboutToRemove: Boolean,
+    takeScreenShot: () -> Unit
 ) {
     val analyticsBoxHeight = remember { mutableStateOf(150.dp) }
     val expanded = rememberSaveable { mutableStateOf(false) }
@@ -182,7 +188,7 @@ private fun Overlay(
     val backgroundColor = if (isAboutToRemove) {
         // Just make the background a bit reddish when removing
         val red = if (isSystemInDarkTheme()) 1f else 0.3f
-        Color.Red
+        Color.Red.copy(alpha = red)
     } else MaterialTheme.colorScheme.background
 
     Box(
@@ -208,6 +214,9 @@ private fun Overlay(
                     .background(backgroundColor)
                     .verticalScroll(rememberScrollState())
             ) {
+                TextButton(onClick = {}) {
+                    Text("Take screenshot of your screen")
+                }
 
             }
         } else {
@@ -215,7 +224,7 @@ private fun Overlay(
                 modifier = analyticsContentModifier
                     .background(backgroundColor)
                     .padding(16.dp),
-                imageVector = Icons.AutoMirrored.Rounded.List,
+                imageVector = Icons.Default.Policy,
                 contentDescription = null
             )
         }

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayService.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayService.kt
@@ -1,29 +1,50 @@
 package com.terrydroid.msgverify.overlay
 
+import android.app.Activity
 import android.app.ActivityManager
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.graphics.Bitmap
 import android.graphics.PixelFormat
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.Image
+import android.media.ImageReader
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
 import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
 import android.os.IBinder
+import android.util.Log
 import android.view.Gravity
 import android.view.WindowInsets
 import android.view.WindowManager
 import android.view.WindowManager.LayoutParams
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.app.NotificationCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.util.Timer
 import kotlin.concurrent.fixedRateTimer
+import androidx.core.graphics.createBitmap
 
-class OverlayService: Service() {
+class OverlayService : Service() {
     override fun onBind(intent: Intent?): IBinder? {
         return null
     }
@@ -59,11 +80,58 @@ class OverlayService: Service() {
         super.onCreate()
         listenAppState()
         addDialogToWindowIfNotAddedAlready()
+        createNotificationChannel()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.getStringExtra("action")) {
+            "START_PROJECTION" -> {
+                val resultCode = intent.getIntExtra("resultCode", Activity.RESULT_CANCELED)
+                val data = intent.getParcelableExtra<Intent>("data")
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    startAsMediaProjectionForeground()
+                    startProjection(resultCode, data)
+                }
+
+            }
+
+            "TAKE_SCREENSHOT" -> {
+                takeScreenshot()
+            }
+        }
         return START_STICKY
     }
+    private val NOTIF_ID = 42
+    private val CHANNEL_ID = "screen_capture"
+
+
+    private fun startAsMediaProjectionForeground() {
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_menu_camera)
+            .setContentTitle("Screen capture active")
+            .setContentText("Capturing screen for text recognition")
+            .setOngoing(true)
+            .build()
+
+        startForeground(
+            NOTIF_ID,
+            notification,
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+        )
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= 26) {
+            val mgr = getSystemService(NotificationManager::class.java)
+            val ch = NotificationChannel(
+                CHANNEL_ID,
+                "Screen capture",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            mgr.createNotificationChannel(ch)
+        }
+    }
+
 
     @Suppress("LongMethod")
     private fun addOverlay() {
@@ -89,6 +157,10 @@ class OverlayService: Service() {
                             x = offset[0].toFloat(),
                             y = offset[1].toFloat(),
                         ) to getStatusBarHeight(windowManager.currentWindowMetrics.windowInsets)
+                    },
+                    takeScreenShot = {
+                        Log.d("CAPTURE","Capturing")
+                        takeScreenshot()
                     },
                     onDragEnd = { offset, shouldRemoveView ->
                         if (shouldRemoveView) {
@@ -130,6 +202,112 @@ class OverlayService: Service() {
         )
     }
 
+    private var mediaProjection: MediaProjection? = null
+    private var virtualDisplay: VirtualDisplay? = null
+    private var imageReader: ImageReader? = null
+
+    fun startProjection(resultCode: Int, data: Intent) {
+        val mpm = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+        mediaProjection = mpm.getMediaProjection(resultCode, data)
+    }
+
+    private fun takeScreenshot() {
+        val projection = mediaProjection ?: return
+
+        val metrics = resources.displayMetrics
+        val width = metrics.widthPixels
+        val height = metrics.heightPixels
+        val density = metrics.densityDpi
+
+        // Create (or recreate) ImageReader
+        imageReader?.close()
+        imageReader = ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 2)
+
+        // Create (or recreate) VirtualDisplay
+        virtualDisplay?.release()
+        virtualDisplay = projection.createVirtualDisplay(
+            "screen-capture",
+            width, height, density,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+            imageReader!!.surface,
+            null,
+            null
+        )
+
+        // Wait briefly for a frame, then acquire it.
+        // In practice you may need to try a couple times.
+        val handlerThread = HandlerThread("ImageReaderThread").apply { start() }
+        val handler = Handler(handlerThread.looper)
+
+        handler.post {
+            var image: Image? = null
+            try {
+                // Try a few times to get a non-null frame
+                repeat(10) {
+                    image = imageReader?.acquireLatestImage()
+                    if (image != null) return@repeat
+                    Thread.sleep(50)
+                }
+
+                val img = image ?: return@post
+                val bitmap = imageToBitmap(img)
+
+                // IMPORTANT: close the image ASAP
+                img.close()
+
+                // Optional: release display if you only need one frame
+                virtualDisplay?.release()
+                virtualDisplay = null
+                imageReader?.close()
+                imageReader = null
+
+                // OCR
+                ocr(
+                    bitmap,
+                    onResult = { text ->
+                        // Use your overlay/UI update here
+                        Log.d("OCR", text)
+                    },
+                    onError = { e ->
+                        Log.e("OCR", "Failed", e)
+                    }
+                )
+            } catch (e: Exception) {
+                Log.e("CAPTURE", "takeScreenshot error", e)
+                image?.close()
+            } finally {
+                handlerThread.quitSafely()
+            }
+        }
+    }
+
+    private fun imageToBitmap(image: Image): Bitmap {
+        val width = image.width
+        val height = image.height
+        val plane = image.planes[0]
+        val buffer = plane.buffer
+
+        val pixelStride = plane.pixelStride
+        val rowStride = plane.rowStride
+        val rowPadding = rowStride - pixelStride * width
+
+        // Create a bitmap accounting for row padding
+        val bitmap = createBitmap(width + rowPadding / pixelStride, height)
+        bitmap.copyPixelsFromBuffer(buffer)
+
+        // Crop to the actual content size
+        return Bitmap.createBitmap(bitmap, 0, 0, width, height)
+    }
+
+    val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+
+    fun ocr(bitmap: Bitmap, onResult: (String) -> Unit, onError: (Exception) -> Unit) {
+        val image = InputImage.fromBitmap(bitmap, 0)
+        recognizer.process(image)
+            .addOnSuccessListener { result -> onResult(result.text) } // <- your string
+            .addOnFailureListener(onError)
+    }
+
     private fun getStatusBarHeight(windowInsets: WindowInsets): Int {
         return windowInsets.getInsets(WindowInsets.Type.systemBars()).top
     }
@@ -145,7 +323,7 @@ class OverlayService: Service() {
             action = {
                 uiScope.launch {
                     //if (isAppInForeground()) {
-                        addDialogToWindowIfNotAddedAlready()
+                    addDialogToWindowIfNotAddedAlready()
                     //} else {
                     //    lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
 //
@@ -219,6 +397,9 @@ class OverlayService: Service() {
     override fun onDestroy() {
         removeViewAndCancelTimer()
         super.onDestroy()
+        imageReader?.close()
+        virtualDisplay?.release()
+        mediaProjection?.stop()
     }
 
     private data class DialogTag(

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayService.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayService.kt
@@ -1,0 +1,227 @@
+package com.terrydroid.msgverify.overlay
+
+import android.app.ActivityManager
+import android.app.Service
+import android.content.Intent
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.IBinder
+import android.view.Gravity
+import android.view.WindowInsets
+import android.view.WindowManager
+import android.view.WindowManager.LayoutParams
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.ComposeView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.util.Timer
+import kotlin.concurrent.fixedRateTimer
+
+class OverlayService: Service() {
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    private val uiScope = CoroutineScope(Job() + Dispatchers.Main)
+
+    private val windowManager
+        get() = getSystemService(WINDOW_SERVICE) as WindowManager
+
+    private var dialog: ComposeView? = null
+    private var timer: Timer? = null
+
+    // Default layout parameters to be used when adding a view to the window.
+    private val defaultLayoutParams = LayoutParams(
+        LayoutParams.WRAP_CONTENT,
+        LayoutParams.WRAP_CONTENT,
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            LayoutParams.TYPE_APPLICATION_OVERLAY
+        } else {
+            @Suppress("deprecation")
+            LayoutParams.TYPE_PHONE
+        },
+        LayoutParams.FLAG_NOT_FOCUSABLE,
+        PixelFormat.TRANSLUCENT
+    ).apply {
+        gravity = Gravity.TOP or Gravity.START
+    }
+
+    private val viewModelStoreOwner = OverlayViewModelStoreOwner()
+    private val lifecycleOwner = OverlayLifecycleOwner()
+
+    override fun onCreate() {
+        super.onCreate()
+        listenAppState()
+        addDialogToWindowIfNotAddedAlready()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_STICKY
+    }
+
+    @Suppress("LongMethod")
+    private fun addOverlay() {
+        dialog = ComposeView(baseContext).apply {
+            setContent {
+                OverlayScreen(
+                    onCancel = { /* No-op */ },
+                    onDragStarted = {
+                        // When the drag started, we need to have the full screen so that
+                        // we can calculate the coordinates of the dragged item correctly.
+                        windowManager.updateViewLayout(
+                            this,
+                            defaultLayoutParams.also {
+                                it.width = LayoutParams.MATCH_PARENT
+                                it.height = LayoutParams.MATCH_PARENT
+                            }
+                        )
+
+                        val offset = IntArray(2)
+                        getLocationOnScreen(offset)
+
+                        Offset(
+                            x = offset[0].toFloat(),
+                            y = offset[1].toFloat(),
+                        ) to getStatusBarHeight(windowManager.currentWindowMetrics.windowInsets)
+                    },
+                    onDragEnd = { offset, shouldRemoveView ->
+                        if (shouldRemoveView) {
+                            // Stopping service will remove the dialog as well
+                            stopSelf()
+                        } else {
+                            // If the user has dragged to the area which is outside of the
+                            // remove area then we need to update the size of this view to
+                            // wrap content again so that we don't cover the whole screen and
+                            // block the user interaction with the underlying content.
+                            windowManager.updateViewLayout(
+                                this,
+                                defaultLayoutParams.also {
+                                    it.width = LayoutParams.WRAP_CONTENT
+                                    it.height = LayoutParams.WRAP_CONTENT
+                                    it.x = offset.x.toInt()
+                                    it.y = offset.y.toInt()
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        dialog?.setViewTreeLifecycleOwner(lifecycleOwner)
+        dialog?.setViewTreeSavedStateRegistryOwner(lifecycleOwner)
+        dialog?.setViewTreeViewModelStoreOwner(viewModelStoreOwner)
+
+        // Trigger lifecycle events to make compose work
+        if (!lifecycleOwner.savedStateRegistry.isRestored) {
+            lifecycleOwner.performRestore(null)
+        }
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+        windowManager.addView(
+            dialog,
+            defaultLayoutParams,
+        )
+    }
+
+    private fun getStatusBarHeight(windowInsets: WindowInsets): Int {
+        return windowInsets.getInsets(WindowInsets.Type.systemBars()).top
+    }
+
+    /**
+     * Since we do not want to touch any activity or application class for getting
+     * lifecycle callbacks to cancel or update the visibility of the view in this
+     * service, we listen the app state (if its in foreground or not).
+     */
+    private fun listenAppState() {
+        timer = fixedRateTimer(
+            period = 500L,
+            action = {
+                uiScope.launch {
+                    //if (isAppInForeground()) {
+                        addDialogToWindowIfNotAddedAlready()
+                    //} else {
+                    //    lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+//
+                    //    removeDialogFromWindowIfVisible()
+                    //}
+                }
+            }
+        )
+    }
+
+    /**
+     * Checks the dialog view tag for the visibility.
+     */
+    private fun isDialogVisible(): Boolean {
+        val visible = (dialog?.tag as? DialogTag)?.visible
+
+        return visible == true
+    }
+
+    private fun setDialogVisibilityTag(visible: Boolean) {
+        dialog?.tag = DialogTag(visible)
+    }
+
+    /**
+     * Checks if the apps is in foreground from the current process.
+     */
+    private fun isAppInForeground(): Boolean {
+        val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager
+        val runningAppProcesses = activityManager.runningAppProcesses
+
+        if (runningAppProcesses != null) {
+            for (processInfo in runningAppProcesses) {
+                // Find the app from the process with its package name
+                if (processInfo.processName == packageName) {
+                    return processInfo.importance == ActivityManager
+                        .RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+                }
+            }
+        }
+
+        // If the app is not in the current process then its not in foreground
+        return false
+    }
+
+    private fun removeViewAndCancelTimer() {
+        removeDialogFromWindowIfVisible()
+        timer?.cancel()
+    }
+
+    /**
+     * Use this function to add the dialog to a window. It handles the visibility tag accordingly.
+     */
+    private fun addDialogToWindowIfNotAddedAlready() {
+        if (!isDialogVisible()) {
+            addOverlay()
+            setDialogVisibilityTag(true)
+        }
+    }
+
+    /**
+     * Use this function to remove the dialog to a window.
+     * It handles the visibility tag accordingly.
+     */
+    private fun removeDialogFromWindowIfVisible() {
+        if (isDialogVisible()) {
+            setDialogVisibilityTag(false)
+            windowManager.removeViewImmediate(dialog)
+        }
+    }
+
+    override fun onDestroy() {
+        removeViewAndCancelTimer()
+        super.onDestroy()
+    }
+
+    private data class DialogTag(
+        val visible: Boolean
+    )
+}

--- a/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayViewStoreOwner.kt
+++ b/composeApp/src/androidMain/kotlin/com/terrydroid/msgverify/overlay/OverlayViewStoreOwner.kt
@@ -1,0 +1,13 @@
+package com.terrydroid.msgverify.overlay
+
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+
+/**
+ * A view model store owner to make overlay service to use compose
+ */
+internal class OverlayViewModelStoreOwner : ViewModelStoreOwner {
+    override val viewModelStore: ViewModelStore
+        get() = ViewModelStore()
+
+}

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/App.kt
@@ -32,13 +32,17 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
 
 @Composable
-fun App() {
-    AppScreen()
+fun App(
+    onOverlayEnable: (enabled: Boolean) -> Unit
+) {
+    AppScreen(onOverlayEnable = onOverlayEnable)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AppScreen() {
+private fun AppScreen(
+    onOverlayEnable: (enabled: Boolean) -> Unit
+) {
     MsgVerifyTheme {
         Column(
             modifier = Modifier
@@ -83,7 +87,8 @@ private fun AppScreen() {
                         },
                     ) { innerPadding ->
                         SettingsScreen(
-                            paddingValues = innerPadding
+                            paddingValues = innerPadding,
+                            onOverlayEnable = onOverlayEnable
                         )
                     }
                 }
@@ -133,6 +138,6 @@ private fun AppScreen() {
 @Composable
 private fun AppPreview() {
     MsgVerifyTheme {
-        AppScreen()
+        AppScreen(onOverlayEnable = {})
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/terrydroid/msgverify/settings/SettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun SettingsScreen(
     paddingValues: PaddingValues,
+    onOverlayEnable: (enabled: Boolean) -> Unit
 ) {
 
     LazyColumn(
@@ -68,6 +69,7 @@ internal fun SettingsScreen(
                     checked = overlayEnabled.value,
                     onCheckedChange = { checked ->
                         overlayEnabled.value = checked
+                        onOverlayEnable(checked)
                     }
                 )
             }


### PR DESCRIPTION
Making it possible to have an overlay button when the app is in background. Then you can take a screenshot of the screen and analyse the text with on device ML kit to extract strings. The plan then is to pipe that into context guard.

Currently a draft as the screenshot part is not working quite yet.

This only works for Android. If we go with something like this, we might want to restrict it on iOS.